### PR TITLE
update README.md for Ionic v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,15 @@ export function jwtOptionsFactory(storage) {
 })
 ```
 
+## Configuration for Ionic 4+
+
+In Ionic v4, as Ionic's `Storage` return a Promise, `then()` is added to `tokenGetter`.
+```ts
+tokenGetter: ()=> {
+  return storage.get('access_token').then((value) => {});
+}
+```
+
 ## Configuration Options
 
 ### `JwtHelperService: service`


### PR DESCRIPTION
ionic storage in v4 return a Promise, then() is required. Otherwise MapSubscriber error has thrown.
see https://github.com/ionic-team/ionic-storage